### PR TITLE
[fix](build): Gemfile(+base64,+csv)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,12 @@ gem "rake", "~> 13.2", ">= 13.2.1"
 
  # If you have any plugins, put them here!
 group :jekyll_plugins do
- 
+
+# { 2024-10-24 @RalphHightower
+# /home/runner/work/blog/blog/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll.rb:28: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of jekyll-4.3.4 to add csv into its gemspec.
+gem 'csv', '~> 3.3'
+# /home/runner/work/blog/blog/vendor/bundle/ruby/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/transform.rb:1: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of safe_yaml-1.0.5 to add base64 into its gemspec.
+gem 'base64', '~> 0.2.0'
+# } 2024-10-24 @RalphHightower
+
 end


### PR DESCRIPTION
```
Run bundle exec jekyll build --trace --baseurl "/minimaUSCGamecockSandstorm"
  bundle exec jekyll build --trace --baseurl "/minimaUSCGamecockSandstorm"
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_PAGES: true
    JEKYLL_ENV: production
    JEKYLL_GITHUB_TOKEN: 
    LOG_LEVEL: debug
bundler: failed to load command: jekyll (/home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/bin/jekyll)
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/psych/parser.rb:62:in `_native_parse': (/home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/_config.yml): did not find expected key while parsing a block mapping at line 28 column 3 (Psych::SyntaxError)
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/psych/parser.rb:62:in `parse'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:143:in `load'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:157:in `block in load_file'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:157:in `open'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:157:in `load_file'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/configuration.rb:129:in `safe_load_file'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/configuration.rb:167:in `read_config_file'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/configuration.rb:198:in `block in read_config_files'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/configuration.rb:195:in `each'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/configuration.rb:195:in `read_config_files'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll.rb:118:in `configuration'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/command.rb:44:in `configuration_from_options'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/commands/build.rb:29:in `process'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/command.rb:91:in `block in process_with_graceful_fail'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/command.rb:91:in `each'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/command.rb:91:in `process_with_graceful_fail'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `block in execute'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `each'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `execute'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/mercenary-0.4.0/lib/mercenary/program.rb:44:in `go'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/mercenary-0.4.0/lib/mercenary.rb:21:in `program'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/gems/jekyll-4.3.4/exe/jekyll:15:in `<top (required)>'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/bin/jekyll:25:in `load'
	from /home/runner/work/minimaUSCGamecockSandstorm/minimaUSCGamecockSandstorm/vendor/bundle/ruby/3.3.0/bin/jekyll:25:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/cli/exec.rb:58:in `load'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/cli/exec.rb:58:in `kernel_load'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/cli/exec.rb:23:in `run'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/cli.rb:455:in `exec'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/cli.rb:35:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/cli.rb:29:in `start'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.11/exe/bundle:28:in `block in <top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/3.3.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.11/exe/bundle:20:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/bin/bundle:25:in `load'
	from /opt/hostedtoolcache/Ruby/3.3.4/x64/bin/bundle:25:in `<main>'
Error: Process completed with exit code 1.
```